### PR TITLE
fix crash when geometry is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,8 @@ PolygonLookup.prototype.loadFeatureCollection = function loadFeatureCollection( 
   }
 
   function indexFeature( poly ){
-    if( poly.geometry.coordinates[ 0 ] !== undefined &&
+    if( poly.geometry &&
+        poly.geometry.coordinates[ 0 ] !== undefined &&
         poly.geometry.coordinates[ 0 ].length > 0){
       switch( poly.geometry.type ){
         case 'Polygon':


### PR DESCRIPTION
Sometimes the geometry in some datasets (some extra features without geometrys)

Rather than crashing on this, just omit the record.
