### PR TITLE
Update searchForMultiplePolygons() to return a GeoJSON FeatureCollection

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,8 +79,8 @@ PolygonLookup.prototype.searchForMultiplePolygons = function searchForMultiplePo
   // keep track of matches to avoid extra expensive calculations if limit reached
   var matchesFound = 0;
 
-  // return all matching polygons, up to the limit
-  return polygons.filter(function(polygon) {
+  // filter matching polygons, up to the limit
+  polygons = polygons.filter(function(polygon) {
     // short circuit if limit reached
     if (matchesFound >= limit) {
       return false;
@@ -93,6 +93,12 @@ PolygonLookup.prototype.searchForMultiplePolygons = function searchForMultiplePo
     }
     return false;
   });
+
+  // return all matching polygons as a GeoJSON FeatureCollection
+  return {
+    type : 'FeatureCollection',
+    features : polygons,
+  };
 };
 
 /**
@@ -103,9 +109,9 @@ PolygonLookup.prototype.searchForMultiplePolygons = function searchForMultiplePo
  * @param {number} x The x-coordinate of the point.
  * @param {number} y The y-coordinate of the point.
  * @param {number} [limit] Number of results to return (-1 to return all the results).
- * @return {undefined|object|array} If one or more bounding box intersections are
+ * @return {undefined|object} If one or more bounding box intersections are
  *    found and limit is undefined, return the first polygon that intersects (`x`, `y`); otherwise,
- *    `undefined`. If a limit is passed in, return intercecting polygons as an array.
+ *    `undefined`. If a limit is passed in, return intercecting polygons as a GeoJSON FeatureCollection.
  */
 PolygonLookup.prototype.search = function search( x, y, limit ){
   if (limit === undefined) {

--- a/test/test.js
+++ b/test/test.js
@@ -190,8 +190,9 @@ tape( 'PolygonLookup.search() respects limit argument.', function ( test ){
     var point = [3, 3];
     var result = lookup.search(point[0], point[1], 1);
 
-    test.equal(result.length, 1, 'array with one element returned');
-    test.equal(result[0].properties.id, 1, 'first polygon returned');
+    test.equal(result.type, 'FeatureCollection', 'feature collection returned');
+    test.equal(result.features.length, 1, 'feature collection with one feature returned');
+    test.equal(result.features[0].properties.id, 1, 'first polygon returned');
     t.end();
   });
 
@@ -199,9 +200,10 @@ tape( 'PolygonLookup.search() respects limit argument.', function ( test ){
     var point = [3, 3];
     var result = lookup.search(point[0], point[1], -1);
 
-    test.equal(result.length, 2, 'array with two elements returned');
-    test.equal(result[0].properties.id, 1, 'first polygon returned');
-    test.equal(result[1].properties.id, 3, 'third polygon returned');
+    test.equal(result.type, 'FeatureCollection', 'feature collection returned');
+    test.equal(result.features.length, 2, 'feature collection with two features returned');
+    test.equal(result.features[0].properties.id, 1, 'first polygon returned');
+    test.equal(result.features[1].properties.id, 3, 'third polygon returned');
     t.end();
   });
 
@@ -209,7 +211,8 @@ tape( 'PolygonLookup.search() respects limit argument.', function ( test ){
     var point = [10, 10];
     var result = lookup.search(point[0], point[1], -1);
 
-    test.equal(result.length, 0, 'empty array returned');
+    test.equal(result.type, 'FeatureCollection', 'feature collection returned');
+    test.equal(result.features.length, 0, 'feature collection with no features returned');
     t.end();
   });
 


### PR DESCRIPTION
I've been thinking, since we are working with GeoJSON objects anyway, why not return a GeoJSON FeatureCollection object instead of returning an array of GeoJSON Feature objects from `searchForMultiplePolygons()`? It makes a cleaner API.

Unfortunately this is a breaking change to v1.3.0 but IMHO it makes more sense to keep a consistent object format throughout the API.

Thoughts? 
