### PR TITLE
Document support for multiple intersecting polygon

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ operates entirely in memory, and works best for polygons with little overlap.
 ##### `PolygonLookup(featureCollection)`
   * `featureCollection` (**optional**): A GeoJSON collection to optionally immediately load with `.loadFeatureCollection()`.
 
-##### `PolygonLookup.search(x, y)`
-Narrows down the candidate polygons by bounding-box, and then performs point-in-polygon intersections to identify the
-first container polygon (and only the first, even if multiple polygons really do intersect).
+##### `PolygonLookup.search(x, y, limit)`
+Narrows down the candidate polygons by bounding-box, and then performs point-in-polygon intersections to identify the first n container polygon (with n = limit, even if more polygons really do intersect).
 
   * `x`: the x-coordinate to search for
   * `y`: the y-coordinate to search for
-  * `return`: the intersecting polygon if one was found; otherwise, `undefined`.
+  * `limit` **optional**: the upper bound for number of intersecting polygon found (default value is 1, -1 to return all intersecting polygons)
+  * `return`: the intersecting polygon if one was found; a GeoJson FeatureCollection if multiple polygons were found and limit > 1; otherwise, `undefined`.
 
 ##### `PolygonLookup.loadFeatureCollection(featureCollection)`
 Stores a feature collection in this `PolygonLookup`, and builds a spatial index for it. The polygons and rtree can be


### PR DESCRIPTION
The option to choose the number of returned polygons was added in https://github.com/pelias/polygon-lookup/commit/ca3878632834dbf6b2a4b00c32bb54987421a40d, but the README was not updated accordingly