### PR TITLE
chore(package): update tape to version 4.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "jshint": "^2.9.4",
     "precommit-hook": "^3.0.0",
     "tap-spec": "^5.0.0",
-    "tape": "^4.6.0"
+    "tape": "^4.10.1"
   },
   "pre-commit": [
     "lint",


### PR DESCRIPTION
Explicitly upgrading to 4.10.1 is required to avoid issues with top-level tests requiring a call to `end()` if there are nested tests.

See https://github.com/substack/tape/issues/459
Fixes #37 